### PR TITLE
Implements issue #83, added default config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ node_modules/
 
 #Ignore gedit temp files
 *.*~
+
+#Ignore config file (has passwords and stuff)
+config.js

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ cd ~/git/email_agent/
 npm install
 node server.js
 ```
+## Configuration
+
+Rename `default-config.js` to `config.js` and set appropriate credentials in the file.
 
 # Features
 

--- a/default-config.js
+++ b/default-config.js
@@ -2,8 +2,8 @@
 // ========
 
 module.exports = {
-	mongodb_username: "admin",
-	mongodb_password: "hunter14",
+	mongodb_username: "username",
+	mongodb_password: "password",
 	mongodb_server : "localhost",
 	mongodb_port: 27017,
 


### PR DESCRIPTION
This adds `default-config.js` with a generic config template. The user must rename this file to `config.js` at configuration time. `config.js` is in the `.gitignore` file so cannot be accidentally committed. :grinning: 

Implements issue #83 